### PR TITLE
[Resolves #5, #23] 회원가입 및 사용자 식별 구현

### DIFF
--- a/backend/gathergo/src/main/java/lightning/gathergo/config/AuthConfig.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/config/AuthConfig.java
@@ -11,12 +11,12 @@ import org.springframework.stereotype.Component;
 public class AuthConfig {
 
     @Bean
-    public FilterRegistrationBean<AuthenticationFilter> loginFilter() {
+    public FilterRegistrationBean<AuthenticationFilter> loginFilter(final AuthenticationFilter filter) {
         // login 필요한 페이지 접속 할 때마다 Session 체크 실행
         FilterRegistrationBean<AuthenticationFilter> registrationBean
                 = new FilterRegistrationBean<>();
 
-        registrationBean.setFilter(new AuthenticationFilter());
+        registrationBean.setFilter(filter);
         registrationBean.addUrlPatterns("/api/write");
         registrationBean.setOrder(1);
 

--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/AuthController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/AuthController.java
@@ -9,10 +9,7 @@ import lightning.gathergo.service.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.*;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -38,7 +35,7 @@ public class AuthController {
         this.userService = userService;
     }
 
-    @PostMapping("/api/login")
+    @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginDto.LoginInput loginDto) {
         Optional<User> user = userService.findUserByUserId(loginDto.getUserId());
 
@@ -56,7 +53,7 @@ public class AuthController {
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<?> signUp(@RequestBody SignupDto.SignupInput signupDto) {
+    public ResponseEntity<?> signUp(@RequestBody SignupDto.SignupInput signupDto, HttpRequest request) {
         String userId = signupDto.getUserId();
         String password = signupDto.getPassword();
         String email = signupDto.getEmail();

--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/AuthController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/AuthController.java
@@ -2,6 +2,7 @@ package lightning.gathergo.controller;
 
 import lightning.gathergo.dto.LoginDto;
 import lightning.gathergo.dto.SignupDto;
+import lightning.gathergo.mapper.SignupDtoMapper;
 import lightning.gathergo.model.Session;
 import lightning.gathergo.model.User;
 import lightning.gathergo.service.SessionService;
@@ -19,20 +20,22 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Optional;
-import java.util.UUID;
 
 @RestController
 public class AuthController {
     private final Logger logger = LoggerFactory.getLogger(AuthController.class);
+
     private final SessionService sessionService;
     private final PasswordEncoder passwordEncoder;
     private final UserService userService;
+    private final SignupDtoMapper signupDtoMapper;
 
     @Autowired
-    public AuthController(SessionService sessionService, PasswordEncoder passwordEncoder, UserService userService) {
+    public AuthController(SessionService sessionService, PasswordEncoder passwordEncoder, UserService userService, SignupDtoMapper signupDtoMapper) {
         this.sessionService = sessionService;
         this.passwordEncoder = passwordEncoder;
         this.userService = userService;
+        this.signupDtoMapper = signupDtoMapper;
     }
 
     @PostMapping("/login")
@@ -47,21 +50,14 @@ public class AuthController {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
-        // headers.add("Set-Cookie", "sessionId:" + session.getSessionId());
 
+        // TODO: Cookie로 세션 전달, Session mapper 만들기
         return new ResponseEntity<>(new LoginDto.LoginSuccessfulResponse("로그인 성공", session, "/"), headers, HttpStatus.OK);
     }
 
     @PostMapping("/signup")
-    public ResponseEntity<?> signUp(@RequestBody SignupDto.SignupInput signupDto, HttpRequest request) {
-        String userId = signupDto.getUserId();
-        String password = signupDto.getPassword();
-        String email = signupDto.getEmail();
-        String UserName = signupDto.getUserName();
-
-        // TODO: Mapper 이용하기
-
-        User user = new User(UUID.randomUUID().toString(), userId, UserName, password, email, "", "");
+    public ResponseEntity<?> signUp(@RequestBody SignupDto.SignupInput signupDto) {
+        User user = signupDtoMapper.toUser(signupDto);
 
         try {
             userService.addUser(user);
@@ -72,6 +68,7 @@ public class AuthController {
         HttpHeaders headers= new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
         headers.add("Location", "/login");
+
         return new ResponseEntity<>(new SignupDto.SignupSuccessfulResponse( "회원가입 성공", "/login"), headers, HttpStatus.OK);
     }
 

--- a/backend/gathergo/src/main/java/lightning/gathergo/dto/SignupDto.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/dto/SignupDto.java
@@ -16,6 +16,13 @@ public class SignupDto {
         private String password;
         private String email;
 
+        public SignupInput(String userId, String userName, String password, String email) {
+            this.userId = userId;
+            this.userName = userName;
+            this.password = password;
+            this.email = email;
+        }
+
         public String getUserId() {
             return userId;
         }

--- a/backend/gathergo/src/main/java/lightning/gathergo/dto/SignupDto.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/dto/SignupDto.java
@@ -1,0 +1,67 @@
+package lightning.gathergo.dto;
+
+import lightning.gathergo.model.Session;
+import lightning.gathergo.model.User;
+import org.springframework.data.relational.core.mapping.Column;
+
+import java.util.UUID;
+
+public class SignupDto {
+    public static class SignupInput {
+        @Column("userid")
+        private String userId;
+
+        @Column("username")
+        private String userName;
+        private String password;
+        private String email;
+
+        public String getUserId() {
+            return userId;
+        }
+
+        public String getUserName() {
+            return userName;
+        }
+
+        public String getPassword() {
+            return password;
+        }
+
+        public String getEmail() {
+            return email;
+        }
+    }
+
+    protected static class SignupResponse {
+        protected String message;
+        protected String redirectUrl;
+
+        protected SignupResponse(String message, String redirectUrl) {
+            this.message = message;
+            this.redirectUrl = redirectUrl;
+        }
+    }
+
+    public static class SignupSuccessfulResponse extends SignupDto.SignupResponse {
+        private Session session;
+
+        public SignupSuccessfulResponse(String message, String redirectUrl) {
+            super(message, redirectUrl);
+        }
+
+        public Session getSession() {
+            return session;
+        }
+    }
+
+    public static class SignupFailedResponse extends SignupDto.SignupResponse {
+        public SignupFailedResponse(String message, String redirectUrl) {
+            super(message, redirectUrl);
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
+}

--- a/backend/gathergo/src/main/java/lightning/gathergo/filter/AuthenticationFilter.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/filter/AuthenticationFilter.java
@@ -1,16 +1,15 @@
 package lightning.gathergo.filter;
 
+import lightning.gathergo.service.CookieService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.*;
-import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.Arrays;
 
 @Order(1)
 @Component
@@ -18,27 +17,23 @@ public class AuthenticationFilter implements Filter {
     // 로그인이 필요한 모든 게시글 url에 대해 동작, 세션이 없으면 로그인 창으로 리다이렉트
     // Session 존재 유무 체크
     private static Logger logger = LoggerFactory.getLogger(AuthenticationFilter.class);
-    private static Cookie nullCookie = new Cookie("sessionId", "");
-    private final static String SESSIONID = "sessionId";
+
+    private final CookieService cookieService;
+
+    public AuthenticationFilter(CookieService cookieService) {
+        this.cookieService = cookieService;
+    }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        // session 정보 존재하는지 확인
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-        Cookie sessionCookie = Arrays.stream(httpRequest.getCookies())
-                .filter((c) -> c.getName().equals(SESSIONID))
-                .findFirst().orElse(nullCookie);
+        // session 정보 존재하는지 확인
+        if(cookieService.retrieveSession(httpRequest.getCookies()) != null)
+            chain.doFilter(request, response);
 
-        String sessionId = sessionCookie.getValue().trim();
-
-        logger.debug(sessionId);
-        if(sessionId.isBlank()) {
-            httpResponse.setStatus(HttpServletResponse.SC_FOUND);
-            httpResponse.setHeader("Location", "/login");
-        }
-
-        chain.doFilter(request, response);
+        httpResponse.setStatus(HttpServletResponse.SC_FOUND);
+        httpResponse.setHeader("Location", "/login");
     }
 }

--- a/backend/gathergo/src/main/java/lightning/gathergo/filter/AuthenticationFilter.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/filter/AuthenticationFilter.java
@@ -30,10 +30,11 @@ public class AuthenticationFilter implements Filter {
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
         // session 정보 존재하는지 확인
-        if(cookieService.retrieveSession(httpRequest.getCookies()) != null)
+        if (cookieService.retrieveSession(httpRequest.getCookies()) == null) {
+            httpResponse.setStatus(HttpServletResponse.SC_FOUND);
+            httpResponse.setHeader("Location", "/login");
+        } else {
             chain.doFilter(request, response);
-
-        httpResponse.setStatus(HttpServletResponse.SC_FOUND);
-        httpResponse.setHeader("Location", "/login");
+        }
     }
 }

--- a/backend/gathergo/src/main/java/lightning/gathergo/filter/AuthenticationFilter.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/filter/AuthenticationFilter.java
@@ -3,6 +3,7 @@ package lightning.gathergo.filter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
 
 import javax.servlet.*;
 import javax.servlet.http.Cookie;
@@ -12,6 +13,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 @Order(1)
+@Component
 public class AuthenticationFilter implements Filter {
     // 로그인이 필요한 모든 게시글 url에 대해 동작, 세션이 없으면 로그인 창으로 리다이렉트
     // Session 존재 유무 체크

--- a/backend/gathergo/src/main/java/lightning/gathergo/filter/AuthenticationFilter.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/filter/AuthenticationFilter.java
@@ -5,35 +5,38 @@ import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.Order;
 
 import javax.servlet.*;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.Arrays;
 
 @Order(1)
 public class AuthenticationFilter implements Filter {
     // 로그인이 필요한 모든 게시글 url에 대해 동작, 세션이 없으면 로그인 창으로 리다이렉트
     // Session 존재 유무 체크
     private static Logger logger = LoggerFactory.getLogger(AuthenticationFilter.class);
+    private static Cookie nullCookie = new Cookie("sessionId", "");
+    private final static String SESSIONID = "sessionId";
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
-        // 1. session 정보 확인하는지 확인
+        // session 정보 존재하는지 확인
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         HttpServletResponse httpResponse = (HttpServletResponse) response;
 
-        try {
-            /*Cookie cookie = Arrays.stream(httpRequest.getCookies())
-                    .filter((c) -> c.getName().equals("sessionId"))
-                    .findFirst().orElseThrow(() -> new RuntimeException("로그인 정보가 존재하지 않습니다"));*/
-            String sessionId = httpRequest.getHeader("sessionId");
-            logger.debug(sessionId);
-            if(sessionId == null)
-                throw new RuntimeException("로그인 정보가 존재하지 않습니다");
-            chain.doFilter(request, response);
+        Cookie sessionCookie = Arrays.stream(httpRequest.getCookies())
+                .filter((c) -> c.getName().equals(SESSIONID))
+                .findFirst().orElse(nullCookie);
 
-        } catch(RuntimeException e) {
+        String sessionId = sessionCookie.getValue().trim();
+
+        logger.debug(sessionId);
+        if(sessionId.isBlank()) {
             httpResponse.setStatus(HttpServletResponse.SC_FOUND);
             httpResponse.setHeader("Location", "/login");
         }
+
+        chain.doFilter(request, response);
     }
 }

--- a/backend/gathergo/src/main/java/lightning/gathergo/mapper/SignupDtoMapper.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/mapper/SignupDtoMapper.java
@@ -1,0 +1,19 @@
+package lightning.gathergo.mapper;
+
+import lightning.gathergo.dto.SignupDto;
+import lightning.gathergo.model.User;
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SignupDtoMapper {
+    private ModelMapper modelMapper;
+
+    public SignupDtoMapper(ModelMapper modelMapper){
+        this.modelMapper = modelMapper;
+    }
+
+    public User toUser(SignupDto.SignupInput dto){
+        return modelMapper.map(dto, User.class);
+    }
+}

--- a/backend/gathergo/src/main/java/lightning/gathergo/model/User.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/model/User.java
@@ -3,6 +3,8 @@ package lightning.gathergo.model;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.relational.core.mapping.Column;
 
+import java.util.UUID;
+
 public class User {
     @Id
     private Integer id;
@@ -33,6 +35,12 @@ public class User {
         this.introduction = introduction;
         this.profilePath = profilePath;
     }
+
+    public User(String userId, String userName, String password, String email) {
+        this(String.valueOf(UUID.randomUUID()), userId, userName, password, email, "", "");
+    }
+
+    public User() { }
 
     public String getUuid() {
         return uuid;

--- a/backend/gathergo/src/main/java/lightning/gathergo/repository/SessionRepository.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/repository/SessionRepository.java
@@ -4,9 +4,9 @@ import lightning.gathergo.model.Session;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 @Component
 public class SessionRepository {
@@ -14,7 +14,8 @@ public class SessionRepository {
      * key: Session id
      * value: Session
      */
-    protected Map<String, Session> sessions = new HashMap<>();  // 테스트 위해 protected
+    protected Map<String, Session> sessions = new ConcurrentHashMap<String, Session>() {
+    };  // 테스트 위해 protected
 
     public Optional<Session> findSessionBySid(String sid) {
         return Optional.ofNullable(this.sessions.get(sid));

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/CookieService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/CookieService.java
@@ -1,0 +1,86 @@
+package lightning.gathergo.service;
+
+import lightning.gathergo.model.Session;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+
+@Service
+public class CookieService {
+    private static final int DEFAULT_COOKIE_EXPIRATION = 3600;
+    public static final String SESSION_ID = "sessionId";
+
+    private static Cookie nullCookie = new Cookie(CookieService.SESSION_ID, "");
+
+    private final SessionService sessionService;
+
+    @Autowired
+    public CookieService(SessionService sessionService) {
+        this.sessionService = sessionService;
+    }
+
+    public void createSessionCookie(String name, String value, HttpServletResponse response) {
+        createSessionCookie(name, value, DEFAULT_COOKIE_EXPIRATION, response);
+    }
+
+    /**
+     * 쿠키 생성 및 반환
+     *
+     * @param name             쿠키 이름
+     * @param value            쿠키 값
+     * @param cookieExpiration 쿠키 만료 시간 (초 단위)
+     * @param response         HttpServletResponse 객체
+     */
+    public void createSessionCookie(String name, String value, int cookieExpiration, HttpServletResponse response) {
+        Cookie sessionCookie = new Cookie(name, value);
+        sessionCookie.setMaxAge(cookieExpiration);
+        sessionCookie.setHttpOnly(true);
+        sessionCookie.setPath("/");
+
+        response.addCookie(sessionCookie);
+    }
+
+    /**
+     * 지정된 이름의 쿠키를 찾기 위해 쿠키를 필터링
+     * 값이 빈 것이 아니면 첫 번째 일치하는 쿠키를 반환하고, 그렇지 않으면 null을 반환
+     *
+     * @param cookies an array of cookies
+     * @param name    the name of the cookie to find
+     * @return the first matching cookie if it exists and its value is not blank, otherwise returns null
+     */
+    public Cookie ifValidCookie(Cookie[] cookies, String name) {
+        Cookie cookie = Arrays.stream(cookies)
+                .filter((c) -> c.getName().equals(name))
+                .findFirst().orElse(nullCookie);
+
+        String cookieValue = cookie.getValue().trim();
+
+        if(!cookieValue.isBlank())
+            return cookie;
+        else
+            return null;
+    }
+
+    /**
+     * 지정된 이름의 쿠키를 검색한 다음 쿠키 값과 일치하는 세션을 세션 저장소에서 찾아서 세션을 검색
+     * 세션이 존재하면 주어진 "sessionId" 에 연관된 SessionRepository에세션을 반환하고, 그렇지 않으면 null을 반환
+     *
+     * @param cookies an array of cookies
+     * @return the session related to "sessionId" in SessionRepository if it exists, otherwise returns null
+     */
+    public Session retrieveSession(Cookie[] cookies) {
+        if (cookies == null) {
+            return null;
+        }
+
+        Cookie foundCookie = ifValidCookie(cookies, SESSION_ID);
+        if(foundCookie == null)
+            return null;
+
+        // SessionRepository에 접근해 expiration 및 세션 정보 일치하는지 확인
+        return sessionService.findSessionBySID(foundCookie.getValue().trim()).orElse(null);
+    }
+}

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/SessionService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/SessionService.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 @Service
@@ -30,9 +31,8 @@ public class SessionService {
         return s;
     }
 
-    public Session findSessionBySID(String sid) {
-        return sessionRepository.findSessionBySid(sid)
-                .orElseThrow(() -> new IllegalArgumentException("해당 유저가 존재하지 않습니다."));
+    public Optional<Session> findSessionBySID(String sid) {
+        return sessionRepository.findSessionBySid(sid);
     }
 
     // TODO: Filter에서 수행

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/UserService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/UserService.java
@@ -5,11 +5,13 @@ import lightning.gathergo.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
 
 @Service
+@Transactional
 public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;

--- a/backend/gathergo/src/test/java/lightning/gathergo/SessionServiceTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/SessionServiceTest.java
@@ -9,12 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -26,10 +23,7 @@ public class SessionServiceTest {
 
     private SessionService sessionService = new SessionService(sessionRepository);
 
-    @BeforeEach
-    void init() {
 
-    }
     @Test
     @DisplayName("Session의 createDate를 DB에 저장 후 읽어온 값이 쓴 값과 일치하는지 테스트")
     public void createDateTest() {
@@ -41,8 +35,10 @@ public class SessionServiceTest {
         logger.debug("getall: {}", sessionRepository.getSessions());
 
         // then
-        Session found = sessionService.findSessionBySID(expected.getSessionId());
-        logger.debug("found uid: {}", found.getSessionId());
-        assertThat(found.getCreateDate()).isEqualTo(found.getCreateDate());
+        Optional<Session> found = sessionService.findSessionBySID(expected.getSessionId());
+
+        assertThat(found).isPresent();
+
+        assertThat(found.get().getCreateDate()).isEqualTo(expected.getCreateDate());
     }
 }

--- a/backend/gathergo/src/test/java/lightning/gathergo/controller/AuthControllerTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/controller/AuthControllerTest.java
@@ -1,5 +1,8 @@
 package lightning.gathergo.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lightning.gathergo.dto.SignupDto;
+import lightning.gathergo.mapper.SignupDtoMapper;
 import lightning.gathergo.model.User;
 import lightning.gathergo.service.UserService;
 import org.junit.jupiter.api.DisplayName;
@@ -28,12 +31,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureMockMvc
 @ActiveProfiles("local")
 public class AuthControllerTest {
+    private final Logger logger = LoggerFactory.getLogger(AuthControllerTest.class);
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
     @Autowired
     private MockMvc mockMvc;
 
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
-    private final Logger logger = LoggerFactory.getLogger(AuthControllerTest.class);
 
     private static String DUMMY_UUID = "705c5b09-bc17-463a-a560-e07e0ac20b23";
 
@@ -80,6 +86,26 @@ public class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("sessionId")))  // 세션 발급
                 .andExpect(content().string(containsString("asdf"))); // userId, userName 반환
+    }
+
+    @Test
+    @DisplayName("회원가입 확인")
+    public void signup() throws Exception {
+        // given
+        SignupDto.SignupInput input = new SignupDto.SignupInput("asdf", "gildong", "12345678", "gildong@gmail.com");
+
+        String jsonInput = objectMapper.writeValueAsString(input);
+        logger.info(jsonInput);
+
+        // when
+        this.mockMvc.perform(post("/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(jsonInput)
+                ).andDo(print())
+                // then
+                .andExpect(status().isOk())
+                .andExpect(header().string("Location", "/login"));  // 리다이렉트
+
     }
 
     @Test

--- a/backend/gathergo/src/test/java/lightning/gathergo/controller/AuthControllerTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/controller/AuthControllerTest.java
@@ -1,8 +1,7 @@
-package lightning.gathergo;
+package lightning.gathergo.controller;
 
 import lightning.gathergo.model.User;
 import lightning.gathergo.service.UserService;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -28,18 +27,18 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Transactional
 @AutoConfigureMockMvc
 @ActiveProfiles("local")
-public class AuthTest {
+public class AuthControllerTest {
     @Autowired
     private MockMvc mockMvc;
 
     private final UserService userService;
     private final PasswordEncoder passwordEncoder;
-    private final Logger logger = LoggerFactory.getLogger(AuthTest.class);
+    private final Logger logger = LoggerFactory.getLogger(AuthControllerTest.class);
 
     private static String DUMMY_UUID = "705c5b09-bc17-463a-a560-e07e0ac20b23";
 
     @Autowired
-    public AuthTest(UserService userService, PasswordEncoder passwordEncoder) {
+    public AuthControllerTest(UserService userService, PasswordEncoder passwordEncoder) {
         this.userService = userService;
         this.passwordEncoder = passwordEncoder;
     }

--- a/backend/gathergo/src/test/java/lightning/gathergo/controller/AuthControllerTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/controller/AuthControllerTest.java
@@ -69,7 +69,7 @@ public class AuthControllerTest {
         userService.addUser(user);
 
         // when
-        this.mockMvc.perform(post("/api/login")
+        this.mockMvc.perform(post("/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("{\n" +
                                 "\"userId\": \"asdf\",\n" +
@@ -80,7 +80,6 @@ public class AuthControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(content().string(containsString("sessionId")))  // 세션 발급
                 .andExpect(content().string(containsString("asdf"))); // userId, userName 반환
-
     }
 
     @Test

--- a/backend/gathergo/src/test/java/lightning/gathergo/controller/AuthControllerTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/controller/AuthControllerTest.java
@@ -39,32 +39,12 @@ public class AuthControllerTest {
     private MockMvc mockMvc;
 
     private final UserService userService;
-    private final PasswordEncoder passwordEncoder;
 
     private static String DUMMY_UUID = "705c5b09-bc17-463a-a560-e07e0ac20b23";
 
     @Autowired
-    public AuthControllerTest(UserService userService, PasswordEncoder passwordEncoder) {
+    public AuthControllerTest(UserService userService) {
         this.userService = userService;
-        this.passwordEncoder = passwordEncoder;
-    }
-
-    @Test
-    @DisplayName("저장된 유저 비밀번호와 주어진 비밀번호가 일치하는지 확인")
-    public void validatePassword() throws Exception {
-        final String rawPassword = "12345678";
-
-        // given
-        User user = new User(DUMMY_UUID, "asdf", "gildong", rawPassword, "asdf@gmail.com", "", "");
-        userService.addUser(user);
-
-        // when
-        Optional<User> found = userService.findUserByUserId("asdf");
-
-        // then
-        assertThat(found.isPresent()).as("userId 검색 결과 %s", found.get()).isTrue();
-        assertThat(passwordEncoder.matches(rawPassword, user.getPassword())).isTrue();
-
     }
 
     @Test

--- a/backend/gathergo/src/test/java/lightning/gathergo/mapper/SignupDtoMapperTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/mapper/SignupDtoMapperTest.java
@@ -42,5 +42,6 @@ public class SignupDtoMapperTest {
                 .build();
 
         softly.assertThat(user).usingRecursiveComparison(configuration).isEqualTo(user);
+        softly.assertAll();
     }
 }

--- a/backend/gathergo/src/test/java/lightning/gathergo/mapper/SignupDtoMapperTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/mapper/SignupDtoMapperTest.java
@@ -1,0 +1,46 @@
+package lightning.gathergo.mapper;
+
+import lightning.gathergo.dto.SignupDto;
+import lightning.gathergo.model.User;
+import org.assertj.core.api.SoftAssertions;
+import org.assertj.core.api.recursive.comparison.RecursiveComparisonConfiguration;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.modelmapper.ModelMapper;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class SignupDtoMapperTest {
+
+    private ModelMapper modelMapper = new ModelMapper();;
+    private SignupDtoMapper signupDtoMapper = new SignupDtoMapper(modelMapper);
+    private SignupDto.SignupInput signupInput;
+
+    @BeforeEach
+    public void setUp() {
+        signupInput = new SignupDto.SignupInput("asdf", "gildong", "12345678", "gildong@gmail.com");
+    }
+
+    @Test
+    @DisplayName("SignupInput(회원가입 요청) User 클래스로 변경하는 mapper 테스트")
+    public void toUser() {
+        // given
+        SoftAssertions softly = new SoftAssertions();
+        // when - signup request
+        User user = signupDtoMapper.toUser(signupInput);
+        // then
+        softly.assertThat(user).hasFieldOrProperty("userId")
+                .hasFieldOrProperty("userName")
+                .hasFieldOrProperty("password")
+                .hasFieldOrProperty("email");
+
+        RecursiveComparisonConfiguration configuration = RecursiveComparisonConfiguration.builder()
+                .withIgnoredFields("introduction")
+                .withIgnoredFields("uuid")
+                .withIgnoredFields("profilePath")
+                .build();
+
+        softly.assertThat(user).usingRecursiveComparison(configuration).isEqualTo(user);
+    }
+}

--- a/backend/gathergo/src/test/java/lightning/gathergo/service/CookieServiceTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/service/CookieServiceTest.java
@@ -1,0 +1,106 @@
+package lightning.gathergo.service;
+
+import lightning.gathergo.model.Session;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.servlet.http.Cookie;
+
+import java.util.UUID;
+
+import static lightning.gathergo.service.CookieService.SESSION_ID;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@ActiveProfiles("local")
+@Transactional
+@SpringBootTest
+class CookieServiceTest {
+    private static final Logger logger = LoggerFactory.getLogger(CookieServiceTest.class);
+
+    private final SessionService sessionService;
+
+    private final CookieService cookieService;
+
+    private final String expectedSessionId = String.valueOf(UUID.randomUUID());
+
+    @Autowired
+    CookieServiceTest(SessionService sessionService, CookieService cookieService) {
+        this.sessionService = sessionService;
+        this.cookieService = cookieService;
+    }
+
+    @Test
+    void testCreateSessionCookie() {
+        SoftAssertions softly = new SoftAssertions();
+
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        cookieService.createSessionCookie(SESSION_ID, expectedSessionId, response);
+
+        Cookie cookie = response.getCookie(SESSION_ID);
+
+        // then
+        assert cookie != null;
+        softly.assertThat(cookie.getName()).isEqualTo(SESSION_ID);
+        softly.assertThat(cookie.getPath()).isEqualTo("/");
+        softly.assertThat(cookie.isHttpOnly()).as("HttpOnly 쿠키?").isTrue();
+        softly.assertThat(cookie.getValue()).isEqualTo(expectedSessionId);
+
+        softly.assertAll();
+    }
+
+    @Test
+    void ifNotValidCookie() {
+        SoftAssertions softly = new SoftAssertions();
+
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        // when
+        cookieService.createSessionCookie(SESSION_ID, expectedSessionId, 0, response);
+
+        Cookie cookie = response.getCookie(SESSION_ID);
+
+        // then
+        assert cookie != null;
+        softly.assertThat(cookie.getName()).isEqualTo(SESSION_ID);
+        softly.assertThat(cookie.getPath()).isEqualTo("/");
+        Cookie[] cookies = {cookie};
+
+        softly.assertThat(cookieService.ifValidCookie(cookies, "expectedSessionId")).isNull();
+        softly.assertAll();
+    }
+
+    @Test
+    void retrieveSession() {
+        SoftAssertions softly = new SoftAssertions();
+
+        // given
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        /*when(sessionService.createSession("asdf", "gildong"))
+                .thenReturn(new Session(expectedSessionId, "Asdf", "gildong", LocalDateTime.now()));*/
+
+        Session createdSession = sessionService.createSession("asdf", "gildong");  // 세션 생성
+
+        cookieService.createSessionCookie(SESSION_ID, createdSession.getSessionId(), 0, response); // 쿠키 생성
+
+        // when
+        Session foundSession = cookieService.retrieveSession(response.getCookies());
+
+        // then
+        assertThat(foundSession).isNotNull();
+        assertThat(createdSession.getSessionId()).isEqualTo(foundSession.getSessionId());
+
+        softly.assertAll();
+    }
+}

--- a/backend/gathergo/src/test/java/lightning/gathergo/service/SessionServiceTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/service/SessionServiceTest.java
@@ -1,9 +1,7 @@
-package lightning.gathergo;
+package lightning.gathergo.service;
 
 import lightning.gathergo.model.Session;
 import lightning.gathergo.repository.SessionRepository;
-import lightning.gathergo.service.SessionService;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/backend/gathergo/src/test/java/lightning/gathergo/service/UserServiceTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/service/UserServiceTest.java
@@ -1,0 +1,51 @@
+package lightning.gathergo.service;
+
+import lightning.gathergo.model.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Transactional
+@ActiveProfiles("local")
+@SpringBootTest
+public class UserServiceTest {
+    private static Logger logger = LoggerFactory.getLogger(UserServiceTest.class);
+    private static String DUMMY_UUID = "705c5b09-bc17-463a-a560-e07e0ac20b23";
+
+    private final UserService userService;
+    private final PasswordEncoder passwordEncoder;
+
+    @Autowired
+    public UserServiceTest(UserService userService, PasswordEncoder passwordEncoder) {
+        this.userService = userService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Test
+    @DisplayName("저장된 유저 비밀번호와 주어진 비밀번호가 일치하는지 확인")
+    public void validatePassword() {
+        final String rawPassword = "12345678";
+
+        // given
+        User user = new User(DUMMY_UUID, "asdf", "gildong", rawPassword, "asdf@gmail.com", "", "");
+        userService.addUser(user);
+
+        // when
+        Optional<User> found = userService.findUserByUserId("asdf");
+
+        // then
+        assertThat(found.isPresent()).as("userId 검색 결과 %s", found.get()).isTrue();
+        assertThat(passwordEncoder.matches(rawPassword, user.getPassword())).isTrue();
+
+    }
+}


### PR DESCRIPTION
## 📌 작업한 내용
<details> <summary>회원가입 및 사용자 식별</summary>

- Cookie를 이용해 SessionId 전달
- SessionId를 이용한 사용자 식별(요청의 SessionId - SessionRepository연동)
- SessionRepository - ConcurrentHashMap으로 변경
- 
</details>


## 📌 추가 논의 사항
 - [ ] EC2에서 테스트