### PR TITLE
[Resolve #44] 로그아웃 구현

### DIFF
--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/AuthController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/AuthController.java
@@ -44,13 +44,12 @@ public class AuthController {
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginDto.LoginInput loginDto, HttpServletResponse response, CookieService cookieService) {
-        Optional<User> user = userService.findUserByUserId(loginDto.getUserId());
+        User loginUser = userService.loginUser(loginDto);
 
-        if (user.isEmpty() || !passwordEncoder.matches(loginDto.getPassword(), user.get().getPassword())) {
-            return new ResponseEntity<>(new LoginDto.LoginFailedResponse("ID나 비밀번호가 일치하지 않습니다", ""), HttpStatus.UNAUTHORIZED);
-        }
+        if(loginUser == null)
+            new ResponseEntity<>(new LoginDto.LoginFailedResponse("ID나 비밀번호가 일치하지 않습니다", ""), HttpStatus.UNAUTHORIZED);
 
-        Session session = sessionService.createSession(user.get().getUserId(), user.get().getUserName());
+        Session session = sessionService.createSession(loginUser.getUserId(), loginUser.getUserName());
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);

--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/AuthController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/AuthController.java
@@ -65,12 +65,7 @@ public class AuthController {
     public ResponseEntity<?> signUp(@RequestBody SignupDto.SignupInput signupDto) {
         User user = signupDtoMapper.toUser(signupDto);
 
-        try {
-            userService.addUser(user);
-        } catch (Exception e) {
-            e.printStackTrace();
-            logger.error("signUp 실패, {}", e.getMessage());
-        }
+        userService.addUser(user);
 
         HttpHeaders headers= new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));

--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/AuthController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/AuthController.java
@@ -71,7 +71,7 @@ public class AuthController {
         headers.setContentType(new MediaType("application", "json", StandardCharsets.UTF_8));
         headers.add("Location", "/login");
 
-        return new ResponseEntity<>(new SignupDto.SignupSuccessfulResponse( "회원가입 성공", "/login"), headers, HttpStatus.OK);
+        return new ResponseEntity<>(new SignupDto.SignupSuccessfulResponse( "회원가입 성공", "/login"), headers, HttpStatus.FOUND);
     }
 
 

--- a/backend/gathergo/src/main/java/lightning/gathergo/exception/ErrorCode.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
     NO_RESOURCE(HttpStatus.NOT_FOUND,"해당 리소스가 존재하지 않습니다"),
     NAME_DUPLICATED(HttpStatus.CONFLICT,"이미 해당명의 리소스가 존재합니다"),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드입니다.");
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "허용되지 않은 메서드입니다."),
+    DUPLICATE_KEY(HttpStatus.CONFLICT, "이미 존재하는 식별자입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/backend/gathergo/src/main/java/lightning/gathergo/exception/GlobalExceptionHandler.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/exception/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package lightning.gathergo.exception;
 
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -20,5 +21,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleLineException(final NoSuchElementException error) {
         ErrorResponse errorResponse = new ErrorResponse(ErrorCode.NO_RESOURCE);
         return new ResponseEntity<ErrorResponse>(errorResponse, HttpStatus.NOT_FOUND);
+    }
+
+    @ExceptionHandler(DuplicateKeyException.class)
+    public ResponseEntity<?> handleConstraintViolationException(final DuplicateKeyException error) {
+        ErrorResponse errorResponse = new ErrorResponse(ErrorCode.DUPLICATE_KEY);
+        return new ResponseEntity<>(errorResponse, HttpStatus.valueOf(errorResponse.getStatus()));
     }
 }

--- a/backend/gathergo/src/main/java/lightning/gathergo/repository/SessionRepository.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/repository/SessionRepository.java
@@ -25,10 +25,9 @@ public class SessionRepository {
         return this.sessions.put(s.getSessionId(), s) == null;
     }
 
-    public void deleteSessionBySid(String sid) {
-        this.sessions.remove(sid);
+    public Session deleteSessionBySid(String sid) {
+        return this.sessions.remove(sid);
     }
-
 
     public Optional<Collection<Session>> getSessions() {
         return Optional.of(this.sessions.values());

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/CookieService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/CookieService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
+import java.util.Optional;
 
 @Service
 public class CookieService {
@@ -37,7 +38,7 @@ public class CookieService {
     public void createSessionCookie(String name, String value, int cookieExpiration, HttpServletResponse response) {
         Cookie sessionCookie = new Cookie(name, value);
         sessionCookie.setMaxAge(cookieExpiration);
-        sessionCookie.setHttpOnly(true);
+        sessionCookie.setHttpOnly(false);
         sessionCookie.setPath("/");
 
         response.addCookie(sessionCookie);
@@ -82,5 +83,22 @@ public class CookieService {
 
         // SessionRepository에 접근해 expiration 및 세션 정보 일치하는지 확인
         return sessionService.findSessionBySID(foundCookie.getValue().trim()).orElse(null);
+    }
+    /**
+     * Cookie의 세션 정보(sessionId)를 통해, SessionRepository의 세션 정보 삭제
+     *
+     * @param cookies an array of cookies
+     * @return 세션 정보가 존재하지 않으면 Null, 이외에는 이전 Session 반환
+     */
+    public Session invalidateSession(Cookie[] cookies) {
+        Cookie foundCookie = ifValidCookie(cookies, SESSION_ID);
+
+        if (cookies == null) {
+            return null;
+        }
+
+        String sessionId = foundCookie.getValue().trim();
+
+        return sessionService.deleteSession(sessionId);
     }
 }

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/CookieService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/CookieService.java
@@ -90,15 +90,19 @@ public class CookieService {
      * @param cookies an array of cookies
      * @return 세션 정보가 존재하지 않으면 Null, 이외에는 이전 Session 반환
      */
-    public Session invalidateSession(Cookie[] cookies) {
-        Cookie foundCookie = ifValidCookie(cookies, SESSION_ID);
-
+    public Session invalidateSession(Cookie[] cookies, HttpServletResponse response) {
         if (cookies == null) {
             return null;
         }
 
+        Cookie foundCookie = ifValidCookie(cookies, SESSION_ID);
+        if (foundCookie.equals(nullCookie)) {
+            return null;
+        }
         String sessionId = foundCookie.getValue().trim();
-
+        foundCookie.setMaxAge(0);
+        foundCookie.setValue("");
+        response.addCookie(foundCookie);
         return sessionService.deleteSession(sessionId);
     }
 }

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/SessionService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/SessionService.java
@@ -31,6 +31,10 @@ public class SessionService {
         return s;
     }
 
+    public Session deleteSession(String sid) {
+        return sessionRepository.deleteSessionBySid(sid);
+    }
+
     public Optional<Session> findSessionBySID(String sid) {
         return sessionRepository.findSessionBySid(sid);
     }

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/UserService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/UserService.java
@@ -1,5 +1,6 @@
 package lightning.gathergo.service;
 
+import lightning.gathergo.dto.LoginDto;
 import lightning.gathergo.model.User;
 import lightning.gathergo.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,5 +50,14 @@ public class UserService {
 
     public void deleteUserByUserId(String userId) {
         userRepository.deleteUserByUserId(userId);
+    }
+
+    public User loginUser(LoginDto.LoginInput loginDto) {
+        Optional<User> user = findUserByUserId(loginDto.getUserId());
+
+        if(user.isEmpty() || !passwordEncoder.matches(loginDto.getPassword(), user.get().getPassword()))
+            return null;
+
+        return user.get();
     }
 }

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/UserService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/UserService.java
@@ -3,6 +3,7 @@ package lightning.gathergo.service;
 import lightning.gathergo.model.User;
 import lightning.gathergo.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,8 +27,12 @@ public class UserService {
     public void addUser(User user) {
         user.setUuid(String.valueOf(UUID.randomUUID()));
         user.setPassword(passwordEncoder.encode(user.getPassword()));
-        // userRepository.save(user);
-        userRepository.save(user.getUuid(), user.getUserId(), user.getUserName(), user.getPassword(), user.getEmail(), "", "");
+        try {
+            userRepository.save(user);
+        } catch (Exception e) {
+            // TODO: Exception 타입에 따라 달리 처리
+            throw new DuplicateKeyException(e.getMessage());
+        }
     }
 
     public User save(User user) {

--- a/backend/gathergo/src/test/java/lightning/gathergo/controller/AuthControllerTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/controller/AuthControllerTest.java
@@ -152,6 +152,7 @@ public class AuthControllerTest {
                         .content("hello")
                 )
                 .andExpect(status().isFound())
-                .andExpect(cookie().doesNotExist(SESSION_ID));
+                .andExpect(cookie().exists(SESSION_ID))
+                .andExpect(cookie().value(SESSION_ID, ""));
     }
 }

--- a/backend/gathergo/src/test/java/lightning/gathergo/repository/SessionRepositoryTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/repository/SessionRepositoryTest.java
@@ -1,17 +1,15 @@
 package lightning.gathergo.repository;
 
 import lightning.gathergo.model.Session;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Import;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -19,7 +17,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class SessionRepositoryTest {
     private static final Logger logger = LoggerFactory.getLogger(SessionRepositoryTest.class);
 
-    private SessionRepository sessionRepository = new SessionRepository();
+    private SessionRepository sessionRepository;
+
+    @BeforeEach
+    public void init() {
+        sessionRepository = new SessionRepository();
+    }
 
     @Test
     @DisplayName("정상 생성 테스트")
@@ -32,5 +35,32 @@ public class SessionRepositoryTest {
 
         // then
         assertThat(result).isEqualTo(true);
+    }
+
+    @Test
+    @DisplayName("없는 세션 삭제 테스트")
+    public void deleteUnValidSession() {
+        // given
+
+        // when
+        Session result = sessionRepository.deleteSessionBySid(String.valueOf(UUID.randomUUID()));
+
+        // then
+        assertThat(result).isEqualTo(null);
+    }
+
+    @Test
+    @DisplayName("있는 세션 삭제 테스트")
+    public void deleteValidSession() {
+        // given
+        String sid = String.valueOf(UUID.randomUUID());
+        Session validSession = new Session("asdf", "asdf");
+        sessionRepository.sessions.put(sid, validSession);
+
+        // when
+        Session result = sessionRepository.deleteSessionBySid(sid);
+
+        // then
+        assertThat(result).isEqualTo(validSession);
     }
 }


### PR DESCRIPTION
## 📌 작업한 내용
<details> <summary>로그아웃 구현</summary>

- 로그아웃 api 추가
- 세션 쿠키 삭제
- 로그아웃 시 SessionRepository의 세션 삭제

</details>


## 📌 추가 논의 사항
- 로그인, 로그아웃 반복으로 세션 정보가 누적되면 SessionRepository에서 만료된 세션 정보 삭제 필요
- refreshToken 구현할지? 
- 세션쿠키의 유효기간은 그대로 두고, Spring 내부적으로 sessionId 연관된 더 짧은 유효기간 관리하기
