### PR TITLE
[Resolves #176] 비동기 요청을 통한 FCM 메시지 전송 성능개선

### DIFF
--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/ArticleController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/ArticleController.java
@@ -209,6 +209,13 @@ public class ArticleController {
         data.setMessage("수정에 성공했습니다.");
         data.setArticleUuid(articleUuid);
 
+        // 닫기 알림 발송
+        Article article = articleService.getArticleByUuid(articleUuid);
+
+        Map<String, String> payload = Map.ofEntries(Map.entry("title", article.getTitle()), Map.entry("body", "호스트가 마감했습니다."));
+
+        messagingService.sendMessageToTopic(articleUuid, payload);
+
         // 구독 정보 삭제
         messagingService.deleteTopicAndDeviceTokens(articleUuid);
 

--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/ArticleController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/ArticleController.java
@@ -185,11 +185,7 @@ public class ArticleController {
         data.setArticleUuid(articleUuid);
 
         // 알림 발송
-        Article article = articleService.getArticleByUuid(articleUuid);
-
-        Map<String, String> messagePayload = Map.ofEntries(Map.entry("title", article.getTitle()), Map.entry("body", "참여한 모임 정보가 변경되었습니다."));
-
-        messagingService.sendMessageToTopic(articleUuid, messagePayload);
+        sendNotification(articleUuid, "참여한 모임 정보가 변경되었습니다.");
 
         return ResponseEntity.ok()
                 .body(new CommonResponseDTO<GatheringDto.MessageResponse>(
@@ -210,11 +206,7 @@ public class ArticleController {
         data.setArticleUuid(articleUuid);
 
         // 닫기 알림 발송
-        Article article = articleService.getArticleByUuid(articleUuid);
-
-        Map<String, String> payload = Map.ofEntries(Map.entry("title", article.getTitle()), Map.entry("body", "호스트가 마감했습니다."));
-
-        messagingService.sendMessageToTopic(articleUuid, payload);
+        sendNotification(articleUuid, "호스트가 게시글을 마감했습니다.");
 
         // 구독 정보 삭제
         messagingService.deleteTopicAndDeviceTokens(articleUuid);
@@ -339,6 +331,15 @@ public class ArticleController {
                                 data
                         )
                 );
+    }
+
+    private void sendNotification(String articleUuid, String body) {
+        Article article = articleService.getArticleByUuid(articleUuid);
+
+        Map<String, String> payload = Map.ofEntries(Map.entry("title", article.getTitle()), Map.entry("body", body));
+
+        // 비동기 요청
+        messagingService.sendMessageToTopic(articleUuid, payload);
     }
 
 }

--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/ArticleController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/ArticleController.java
@@ -300,13 +300,6 @@ public class ArticleController {
         data.setArticleUuid(articleUuid);
         data.setMessage("참가에 성공했습니다.");
 
-        // 알림 발송
-        Article article = articleService.getArticleByUuid(articleUuid);
-
-        Map<String, String> messagePayload = Map.ofEntries(Map.entry("title", article.getTitle()), Map.entry("body", session.getUserName() + "님이 모임에 참가했습니다."));
-
-        messagingService.sendMessageToTopic(articleUuid, messagePayload);
-
         return ResponseEntity.ok()
                 .body(new CommonResponseDTO<GatheringDto.MessageResponse>(
                                 1,

--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/DummyController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/DummyController.java
@@ -39,7 +39,9 @@ public class DummyController {
     public ResponseEntity<CommonResponseDTO<?>> pushNotificationToTopic(@RequestBody String topic) {
         // 기기 토큰을 받고 메시지를 발행하는 테스트 컨트롤러
         System.out.println(topic);
-        String result = fcmMessagingService
+        String result = "";
+
+        fcmMessagingService
                 .sendMessageToTopic(topic, Map.ofEntries(Map.entry("title", "api test")));
         return new ResponseEntity<>(new CommonResponseDTO<>(result.isBlank()?0:1, "hello!", result), HttpStatus.OK);
     }  // 주어진 topic으로 push 보내는 더미 컨트롤러

--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/SubscriptionController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/SubscriptionController.java
@@ -24,44 +24,40 @@ public class SubscriptionController {
 
     @PostMapping
     public ResponseEntity<CommonResponseDTO<?>> subscribe(@RequestBody SubscriptionDto.Request request) {
-        CommonResponseDTO<Object> responseDto;
-
-        String deviceToken = request.getDeviceToken();
-        String articleId = request.getArticleId();
-
-        if(deviceToken == null || deviceToken.isBlank() || articleId == null || articleId.isBlank())
-            return new ResponseEntity<>(new CommonResponseDTO<>(0, articleId + " 구독 실패", null), HttpStatus.BAD_REQUEST);
-
-        logger.info("topic 구독 {}, {}", articleId, deviceToken);
-
-        boolean subscribed = messagingService.subscribeToTopic(articleId, deviceToken);
-
-        if(subscribed)
-            responseDto = new CommonResponseDTO<>(1, articleId + " 구독 성공", null);
-        else
-            responseDto = new CommonResponseDTO<>(0, articleId + " 구독 실패", null);
-
-        return new ResponseEntity<>(responseDto, HttpStatus.OK);
+        return handleSubscriptionRequest(request, true);
     }
 
     @DeleteMapping
     public ResponseEntity<CommonResponseDTO<?>> unsubscribe(@RequestBody SubscriptionDto.Request request) {
+        return handleSubscriptionRequest(request, false);
+    }
+
+    private ResponseEntity<CommonResponseDTO<?>> handleSubscriptionRequest(SubscriptionDto.Request request, boolean isSubscribe) {
         CommonResponseDTO<Object> responseDto;
+        boolean success;
 
         String deviceToken = request.getDeviceToken();
         String articleId = request.getArticleId();
 
-        if(deviceToken == null || deviceToken.isBlank() || articleId == null || articleId.isBlank())
-            return new ResponseEntity<>(new CommonResponseDTO<>(0, articleId + " 구독 해제 실패", null), HttpStatus.BAD_REQUEST);
+        // validation
+        if(deviceToken == null || deviceToken.isBlank() || articleId == null || articleId.isBlank()) {
+            return new ResponseEntity<>(new CommonResponseDTO<>(0, articleId + (isSubscribe ? " 구독 실패" : " 구독 해제 실패"), null), HttpStatus.BAD_REQUEST);
+        }
 
-        logger.info("topic 구독 해제 {}, {}", articleId, deviceToken);
+        logger.info("topic {} {}, {}", articleId, (isSubscribe ? "구독" : "구독 해제"), deviceToken);
 
-        boolean unSubscribed = messagingService.unsubscribeFromTopic(articleId, deviceToken);
+        String action;
 
-        if(unSubscribed)
-            responseDto = new CommonResponseDTO<>(1, articleId + " 구독 해제 성공", null);
-        else
-            responseDto = new CommonResponseDTO<>(0, articleId + " 구독 해제 실패", null);
+        if (isSubscribe) {
+            success = messagingService.subscribeToTopic(articleId, deviceToken);
+            action = "구독";
+        } else {
+            success = messagingService.unsubscribeFromTopic(articleId, deviceToken);
+            action = "구독 해제";
+        }
+
+        String message = articleId + (success ? " " + action + " 성공" : " " + action + " 실패");
+        responseDto = new CommonResponseDTO<>(success ? 1 : 0, message, null);
 
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }

--- a/backend/gathergo/src/main/java/lightning/gathergo/controller/SubscriptionController.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/controller/SubscriptionController.java
@@ -29,6 +29,9 @@ public class SubscriptionController {
         String deviceToken = request.getDeviceToken();
         String articleId = request.getArticleId();
 
+        if(deviceToken == null || deviceToken.isBlank() || articleId == null || articleId.isBlank())
+            return new ResponseEntity<>(new CommonResponseDTO<>(0, articleId + " 구독 실패", null), HttpStatus.BAD_REQUEST);
+
         logger.info("topic 구독 {}, {}", articleId, deviceToken);
 
         boolean subscribed = messagingService.subscribeToTopic(articleId, deviceToken);
@@ -47,6 +50,9 @@ public class SubscriptionController {
 
         String deviceToken = request.getDeviceToken();
         String articleId = request.getArticleId();
+
+        if(deviceToken == null || deviceToken.isBlank() || articleId == null || articleId.isBlank())
+            return new ResponseEntity<>(new CommonResponseDTO<>(0, articleId + " 구독 해제 실패", null), HttpStatus.BAD_REQUEST);
 
         logger.info("topic 구독 해제 {}, {}", articleId, deviceToken);
 

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/FcmMessagingService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/FcmMessagingService.java
@@ -18,12 +18,16 @@ import org.springframework.transaction.annotation.Transactional;
 import javax.annotation.PostConstruct;
 import java.io.IOException;
 import java.io.InputStream;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.*;
 
 @Service
 public class FcmMessagingService {
     private final Logger logger = LoggerFactory.getLogger(FcmMessagingService.class);
+
+    private final ExecutorService executorService = Executors.newFixedThreadPool(2);
 
     private final SubscriptionRepository subscriptionRepository;
 
@@ -175,12 +179,34 @@ public class FcmMessagingService {
         notificationRepository.save(topic, datas.get("title"), datas.get("body"));
 
         // 2. 알림 발송
-        Message message = Message.builder()
-                .putAllData(datas)
-                .setTopic(topic)
-                .build();  // .setCondition 추가하면 한 번에 여러 topic에도 전달 가능
 
-        return send(message);
+        sendAsyncMessageToTopic(datas, topic);
+    }
+
+
+
+    public void sendAsyncMessageToTopic(Map<String, String> datas, String topic) {
+        Instant start = Instant.now();
+
+        executorService.submit(() -> {
+            Message message = Message.builder()
+                    .putAllData(datas)
+                    .setTopic(topic)
+                    .build();
+
+            try {
+                String response = FirebaseMessaging.getInstance().send(message);
+
+                Instant end = Instant.now();
+                Duration duration = Duration.between(start, end);
+                logger.info("Successfully sent message to: {}, took: {}", topic, duration);
+
+                return response;
+            } catch (FirebaseMessagingException e) {
+                logger.error(e.getMessage());
+                throw e;
+            }
+        });
     }
 
     public String sendMessageToToken(String token, String body) {

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/FcmMessagingService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/FcmMessagingService.java
@@ -85,6 +85,7 @@ public class FcmMessagingService {
      * @param deviceToken 기기 식별토큰
      * @return 성공 여부
      */
+    @Transactional
     public boolean subscribeToTopic(String topic, String deviceToken) {
         registrationTokens.computeIfAbsent(topic, k -> new HashSet<>()).add(deviceToken);
 
@@ -122,6 +123,7 @@ public class FcmMessagingService {
      * @param deviceToken 기기 식별토큰
      * @return 성공 여부
      */
+    @Transactional
     public boolean unsubscribeFromTopic(String topic, String deviceToken) {
         TopicManagementResponse response = null;
         int affectedRows;  // DB에서 삭제된 구독 정보의 수, 정상 동작은 1을 반환

--- a/backend/gathergo/src/main/java/lightning/gathergo/service/FcmMessagingService.java
+++ b/backend/gathergo/src/main/java/lightning/gathergo/service/FcmMessagingService.java
@@ -178,12 +178,9 @@ public class FcmMessagingService {
         // 1. 알림 내역 저장
         notificationRepository.save(topic, datas.get("title"), datas.get("body"));
 
-        // 2. 알림 발송
-
+        // 2. 알림 발송, 비동기 처리
         sendAsyncMessageToTopic(datas, topic);
     }
-
-
 
     public void sendAsyncMessageToTopic(Map<String, String> datas, String topic) {
         Instant start = Instant.now();

--- a/backend/gathergo/src/test/java/lightning/gathergo/repository/NotificationRepositoryTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/repository/NotificationRepositoryTest.java
@@ -1,0 +1,65 @@
+package lightning.gathergo.repository;
+
+import lightning.gathergo.model.Article;
+import lightning.gathergo.model.Notification;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.sql.Timestamp;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.mockito.Mockito.when;
+
+// @ExtendWith(SpringExtension.class)
+@SpringBootTest
+@ActiveProfiles("local")
+@Transactional
+public class NotificationRepositoryTest {
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    private final String DUMMY_UUID = "dd5c1220-841b-4be0-9518-795fc6f4dd0a";
+
+    @MockBean
+    private ArticleRepository articleRepository;
+
+    @Test
+    @DisplayName("참여중인 게시글 기준으로 등록된 알림 내역 uuid로 찾아오기 테스기")
+    void save() {
+
+        // given
+        // when(articleRepository.findByUuid(DUMMY_UUID)).thenReturn(Optional.of(new Article(1, "테스트 새 글 1", 2, false, "내용", Timestamp.valueOf("2023-02-21 12:12:12"), "서울시 성동구", 1, 1, DUMMY_UUID)));
+        String uuid1 = String.valueOf(UUID.randomUUID());
+        String uuid2 = String.valueOf(UUID.randomUUID());
+
+        Article article1 = new Article(1, "테스트 새 글 1", 2, false, "내용1", Timestamp.valueOf("2023-02-21 12:12:12"), "서울시 성동구", 1, 1, uuid1);
+        Article article2 = new Article(2, "테스트 새 글 2", 4, false, "내용2", Timestamp.valueOf("2023-02-22 12:12:13"), "서울시 중구", 1, 1, uuid1);
+
+        // 각각 article1, article2에 댓글과 새 글, 특정 유저 참여 가정
+        notificationRepository.save(uuid1, article1.getTitle(), "댓글이 등록되었습니다", Timestamp.valueOf("2023-02-21 12:12:12"));
+        notificationRepository.save(uuid2, article2.getTitle(), "a님이 참여하셧습니다", Timestamp.valueOf("2023-02-22 12:12:13"));
+
+        // when
+        // (게시글 참여 = 구독) 정보 기반으로 uuid 등록된 알림 내역 잘 찾아오는지 쿼리 테스트
+        List<Notification> notifications = notificationRepository.findByArticleIds(List.of(uuid1, uuid2));
+
+        notifications.sort(Comparator.comparing(Notification::getIssueDateTime));
+
+        // then
+        assertThat(notifications)
+                .usingRecursiveComparison()
+                .ignoringFields("id")
+                .isEqualTo(List.of(
+                new Notification(uuid1, article1.getTitle(), "댓글이 등록되었습니다", article1.getMeetingDay()),
+                new Notification(uuid2, article2.getTitle(), "a님이 참여하셧습니다", article2.getMeetingDay())
+        ));
+    }
+}

--- a/backend/gathergo/src/test/java/lightning/gathergo/service/FcmMessagingServiceTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/service/FcmMessagingServiceTest.java
@@ -17,6 +17,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.*;
 
 import static org.mockito.Mockito.when;
@@ -48,7 +50,13 @@ public class FcmMessagingServiceTest {
         final String deviceToken = String.valueOf(UUID.randomUUID());
 
         // when
+        Instant start = Instant.now();
+
         boolean result = messagingService.subscribeToTopic(topic, deviceToken);
+        Instant end = Instant.now();
+
+        Duration duration = Duration.between(start, end);
+        logger.info("Successfully subscribed to topic : {}, it took: {}", topic, duration);
 
         when(subscriptionRepository.findByArticleId(topic)).thenReturn(List.of(new Subscription(topic, deviceToken)));
         // cleanUp(List.of(deviceToken), topic);

--- a/backend/gathergo/src/test/java/lightning/gathergo/service/FcmMessagingServiceTest.java
+++ b/backend/gathergo/src/test/java/lightning/gathergo/service/FcmMessagingServiceTest.java
@@ -59,7 +59,7 @@ public class FcmMessagingServiceTest {
         logger.info("Successfully subscribed to topic : {}, it took: {}", topic, duration);
 
         when(subscriptionRepository.findByArticleId(topic)).thenReturn(List.of(new Subscription(topic, deviceToken)));
-        // cleanUp(List.of(deviceToken), topic);
+        cleanUp(List.of(deviceToken), topic);
 
         softly.assertThat(result).isTrue();
         softly.assertThat(subscriptionRepository.findByArticleId(topic)).isNotNull().hasSize(1);
@@ -82,7 +82,7 @@ public class FcmMessagingServiceTest {
 
         when(subscriptionRepository.findByArticleId(topic)).thenReturn(List.of(new Subscription(topic, deviceToken1), new Subscription(topic, deviceToken2)));
 
-        // cleanUp(List.of(deviceToken1, deviceToken2), topic);
+        cleanUp(List.of(deviceToken1, deviceToken2), topic);
 
         softly.assertThat(result).isTrue();
         softly.assertThat(subscriptionRepository.findByArticleId(topic)).isNotNull().hasSize(2);
@@ -103,18 +103,18 @@ public class FcmMessagingServiceTest {
         boolean result = messagingService.subscribeToTopic(topic, deviceToken);
 
         when(subscriptionRepository.findByArticleId(topic)).thenReturn(List.of(new Subscription(topic, deviceToken)));
-        // cleanUp(List.of(deviceToken), topic);
+        cleanUp(List.of(deviceToken), topic);
 
         softly.assertThat(result).isTrue();
         softly.assertThat(subscriptionRepository.findByArticleId(topic)).isNotNull().hasSize(1);
         softly.assertAll();
     }
 
-    private void cleanUp(List<String> tokens, int topic) {
+    private void cleanUp(List<String> tokens, String topic) {
 
         try {
             FirebaseMessaging.getInstance()
-                    .unsubscribeFromTopic(tokens, String.valueOf(topic));
+                    .unsubscribeFromTopic(tokens, topic);
         } catch (FirebaseMessagingException e) {
             logger.error("could not add token to given topic: {}, {}", topic, e.getMessage());
         }


### PR DESCRIPTION
## 📌 작업한 내용
<details> <summary>ExecutorService 이용해 비동기 요청으로 변경</summary>

- 모임 참여자에게 댓글 등록, 게시글 내용 수정 시 알림 발송 비동기 요청으로 변경

</details>

### 기존 요청 응답시간
<img width="1296" alt="스크린샷 2023-02-21 오전 12 09 21" src="https://user-images.githubusercontent.com/33480561/220283109-1bdde1aa-8763-4176-a740-e8d34f74cf3d.png">

### 개선 요청 응답시간
<img width="1297" alt="스크린샷 2023-02-21 오전 12 11 41" src="https://user-images.githubusercontent.com/33480561/220283021-fd9f0a6a-7c70-482b-9441-d1fac118ea0c.png">

## 📌 추가 논의 사항
